### PR TITLE
Use wallet-adapter-core as a normal dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aptos-labs/wallet-adapter-core": "^2.6.0",
         "@identity-connect/api": "^0.4.1",
         "@identity-connect/dapp-sdk": "^0.4.3",
         "@identity-connect/wallet-api": "^0.0.4"
@@ -22,7 +23,6 @@
         "typescript": "^5.3.2"
       },
       "peerDependencies": {
-        "@aptos-labs/wallet-adapter-core": "^2.6.0",
         "aptos": "^1.20.0"
       }
     },
@@ -64,7 +64,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-0.0.3.tgz",
       "integrity": "sha512-1qVcKAMToLI+EOrw0kQvL9/yyXZ7iU4/NIpvFokIWK6DNe3ExSu+SebwFc0jAqyy/kvMWht8FBF2hnmW2G1pyA==",
-      "peer": true,
       "dependencies": {
         "@aptos-labs/aptos-client": "^0.0.2",
         "@noble/curves": "^1.2.0",
@@ -81,7 +80,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-2.6.0.tgz",
       "integrity": "sha512-GVnjnwzW/dnEW1ceHUB6vj9u37Hth38oIngc4ERdXf9cl9BlXut4e0bLHCUrbHGOtF7rx1NuDVwYH7GYsh6vSQ==",
-      "peer": true,
       "dependencies": {
         "@aptos-labs/ts-sdk": "^0.0.3",
         "buffer": "^6.0.3",
@@ -1451,7 +1449,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -1463,7 +1460,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -2306,8 +2302,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -2407,7 +2402,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -2940,8 +2934,7 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "peer": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -3317,8 +3310,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/ignore": {
       "version": "5.2.1",
@@ -5610,7 +5602,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-0.0.3.tgz",
       "integrity": "sha512-1qVcKAMToLI+EOrw0kQvL9/yyXZ7iU4/NIpvFokIWK6DNe3ExSu+SebwFc0jAqyy/kvMWht8FBF2hnmW2G1pyA==",
-      "peer": true,
       "requires": {
         "@aptos-labs/aptos-client": "^0.0.2",
         "@noble/curves": "^1.2.0",
@@ -5624,7 +5615,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-2.6.0.tgz",
       "integrity": "sha512-GVnjnwzW/dnEW1ceHUB6vj9u37Hth38oIngc4ERdXf9cl9BlXut4e0bLHCUrbHGOtF7rx1NuDVwYH7GYsh6vSQ==",
-      "peer": true,
       "requires": {
         "@aptos-labs/ts-sdk": "^0.0.3",
         "buffer": "^6.0.3",
@@ -6570,7 +6560,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "peer": true,
       "requires": {
         "@noble/hashes": "1.3.2"
       },
@@ -6578,8 +6567,7 @@
         "@noble/hashes": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-          "peer": true
+          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
         }
       }
     },
@@ -7154,8 +7142,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "peer": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -7216,7 +7203,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "peer": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -7594,8 +7580,7 @@
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "peer": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "execa": {
       "version": "5.1.1",
@@ -7858,8 +7843,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "peer": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@identity-connect/wallet-adapter-plugin",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@identity-connect/wallet-adapter-plugin",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aptos-labs/wallet-adapter-core": "^2.6.0",
+        "@aptos-labs/wallet-adapter-core": "^3.5.0",
         "@identity-connect/api": "^0.4.1",
         "@identity-connect/dapp-sdk": "^0.4.3",
         "@identity-connect/wallet-api": "^0.0.4"
@@ -40,54 +40,54 @@
       }
     },
     "node_modules/@aptos-labs/aptos-client": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-0.0.2.tgz",
-      "integrity": "sha512-FgKZb5zDPz8MmAcVxXzYhxP6OkzuIPoDRJp48YJ8+vrZ9EOZ35HaWGN2M3u+GPdnFE9mODFqkxw3azh3kHGZjQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-0.1.0.tgz",
+      "integrity": "sha512-q3s6pPq8H2buGp+tPuIRInWsYOuhSEwuNJPwd2YnsiID3YSLihn2ug39ktDJAcSOprUcp7Nid8WK7hKqnUmSdA==",
       "dependencies": {
-        "axios": "0.27.2",
-        "got": "^11.0.0"
+        "axios": "1.6.2",
+        "got": "^11.8.6"
       },
       "engines": {
         "node": ">=15.10.0"
       }
     },
-    "node_modules/@aptos-labs/aptos-client/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
     "node_modules/@aptos-labs/ts-sdk": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-0.0.3.tgz",
-      "integrity": "sha512-1qVcKAMToLI+EOrw0kQvL9/yyXZ7iU4/NIpvFokIWK6DNe3ExSu+SebwFc0jAqyy/kvMWht8FBF2hnmW2G1pyA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.11.0.tgz",
+      "integrity": "sha512-iy4bcHHVfRxcMgrdZEl6KBu2NeWpD9oMMli43R82eBLHfBO+LjDHdkr9GcFE5FE6ogt0EP9EWQk8TcjZmWkyVg==",
+      "peer": true,
       "dependencies": {
-        "@aptos-labs/aptos-client": "^0.0.2",
+        "@aptos-labs/aptos-client": "^0.1.0",
         "@noble/curves": "^1.2.0",
-        "@noble/hashes": "1.1.3",
-        "@scure/bip39": "1.1.0",
-        "form-data": "4.0.0",
-        "tweetnacl": "1.0.3"
+        "@noble/hashes": "^1.3.3",
+        "@scure/bip32": "^1.3.3",
+        "@scure/bip39": "^1.2.1",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.0",
+        "tweetnacl": "^1.0.3"
       },
       "engines": {
         "node": ">=11.0.0"
       }
     },
+    "node_modules/@aptos-labs/ts-sdk/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "peer": true
+    },
     "node_modules/@aptos-labs/wallet-adapter-core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-2.6.0.tgz",
-      "integrity": "sha512-GVnjnwzW/dnEW1ceHUB6vj9u37Hth38oIngc4ERdXf9cl9BlXut4e0bLHCUrbHGOtF7rx1NuDVwYH7GYsh6vSQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-3.6.0.tgz",
+      "integrity": "sha512-xSwlOlTmBgFvPMDBlD/7D7FSJ22ioC8z3O6iYQls1qvV2ibrL6RThGKMC8QD2qus9f0rP9523RLNJT4P/RvSOg==",
       "dependencies": {
-        "@aptos-labs/ts-sdk": "^0.0.3",
         "buffer": "^6.0.3",
         "eventemitter3": "^4.0.7",
         "tweetnacl": "^1.0.3"
       },
       "peerDependencies": {
-        "aptos": "^1.19.0"
+        "@aptos-labs/ts-sdk": "^1.6.0",
+        "aptos": "^1.21.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1033,17 +1033,6 @@
         "tweetnacl": "^1.0.3"
       }
     },
-    "node_modules/@identity-connect/crypto/node_modules/@noble/hashes": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
-      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@identity-connect/dapp-sdk": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@identity-connect/dapp-sdk/-/dapp-sdk-0.4.3.tgz",
@@ -1446,37 +1435,27 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
+      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "peer": true,
       "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/curves/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "engines": {
-        "node": ">= 16"
+        "@noble/hashes": "1.4.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1670,29 +1649,38 @@
       ]
     },
     "node_modules/@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
+      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
-      "integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "peer": true,
       "dependencies": {
-        "@noble/hashes": "~1.1.1",
-        "@scure/base": "~1.1.0"
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1996,9 +1984,9 @@
       }
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -2048,9 +2036,9 @@
       "integrity": "sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g=="
     },
     "node_modules/@types/responselike": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2135,19 +2123,42 @@
       }
     },
     "node_modules/aptos": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.20.0.tgz",
-      "integrity": "sha512-driZt7qEr4ndKqqVHMyuFsQAHy4gJ4HPQttgVIpeDfnOIEnIV7A2jyJ9EYO2A+MayuyxXB+7yCNXT4HyBFJdpA==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.21.0.tgz",
+      "integrity": "sha512-PRKjoFgL8tVEc9+oS7eJUv8GNxx8n3+0byH2+m7CP3raYOD6yFKOecuwjVMIJmgfpjp6xH0P0HDMGZAXmSyU0Q==",
       "dependencies": {
-        "@aptos-labs/aptos-client": "^0.0.2",
-        "@noble/hashes": "1.1.3",
-        "@scure/bip39": "1.1.0",
+        "@aptos-labs/aptos-client": "^0.1.0",
+        "@noble/hashes": "1.3.3",
+        "@scure/bip39": "1.2.1",
         "eventemitter3": "^5.0.1",
         "form-data": "4.0.0",
         "tweetnacl": "1.0.3"
       },
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/aptos/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/aptos/node_modules/@scure/bip39": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "dependencies": {
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/aptos/node_modules/eventemitter3": {
@@ -2179,9 +2190,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -4161,9 +4172,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
-      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -5579,44 +5590,43 @@
       }
     },
     "@aptos-labs/aptos-client": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-0.0.2.tgz",
-      "integrity": "sha512-FgKZb5zDPz8MmAcVxXzYhxP6OkzuIPoDRJp48YJ8+vrZ9EOZ35HaWGN2M3u+GPdnFE9mODFqkxw3azh3kHGZjQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-0.1.0.tgz",
+      "integrity": "sha512-q3s6pPq8H2buGp+tPuIRInWsYOuhSEwuNJPwd2YnsiID3YSLihn2ug39ktDJAcSOprUcp7Nid8WK7hKqnUmSdA==",
       "requires": {
-        "axios": "0.27.2",
-        "got": "^11.0.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-          "requires": {
-            "follow-redirects": "^1.14.9",
-            "form-data": "^4.0.0"
-          }
-        }
+        "axios": "1.6.2",
+        "got": "^11.8.6"
       }
     },
     "@aptos-labs/ts-sdk": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-0.0.3.tgz",
-      "integrity": "sha512-1qVcKAMToLI+EOrw0kQvL9/yyXZ7iU4/NIpvFokIWK6DNe3ExSu+SebwFc0jAqyy/kvMWht8FBF2hnmW2G1pyA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.11.0.tgz",
+      "integrity": "sha512-iy4bcHHVfRxcMgrdZEl6KBu2NeWpD9oMMli43R82eBLHfBO+LjDHdkr9GcFE5FE6ogt0EP9EWQk8TcjZmWkyVg==",
+      "peer": true,
       "requires": {
-        "@aptos-labs/aptos-client": "^0.0.2",
+        "@aptos-labs/aptos-client": "^0.1.0",
         "@noble/curves": "^1.2.0",
-        "@noble/hashes": "1.1.3",
-        "@scure/bip39": "1.1.0",
-        "form-data": "4.0.0",
-        "tweetnacl": "1.0.3"
+        "@noble/hashes": "^1.3.3",
+        "@scure/bip32": "^1.3.3",
+        "@scure/bip39": "^1.2.1",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.0",
+        "tweetnacl": "^1.0.3"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+          "peer": true
+        }
       }
     },
     "@aptos-labs/wallet-adapter-core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-2.6.0.tgz",
-      "integrity": "sha512-GVnjnwzW/dnEW1ceHUB6vj9u37Hth38oIngc4ERdXf9cl9BlXut4e0bLHCUrbHGOtF7rx1NuDVwYH7GYsh6vSQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-3.6.0.tgz",
+      "integrity": "sha512-xSwlOlTmBgFvPMDBlD/7D7FSJ22ioC8z3O6iYQls1qvV2ibrL6RThGKMC8QD2qus9f0rP9523RLNJT4P/RvSOg==",
       "requires": {
-        "@aptos-labs/ts-sdk": "^0.0.3",
         "buffer": "^6.0.3",
         "eventemitter3": "^4.0.7",
         "tweetnacl": "^1.0.3"
@@ -6226,13 +6236,6 @@
         "aptos": "^1.14.0",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
-      },
-      "dependencies": {
-        "@noble/hashes": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
-          "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
-        }
       }
     },
     "@identity-connect/dapp-sdk": {
@@ -6557,24 +6560,18 @@
       }
     },
     "@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
+      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "peer": true,
       "requires": {
-        "@noble/hashes": "1.3.2"
-      },
-      "dependencies": {
-        "@noble/hashes": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
-        }
+        "@noble/hashes": "1.4.0"
       }
     },
     "@noble/hashes": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6687,17 +6684,29 @@
       "optional": true
     },
     "@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
+      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g=="
+    },
+    "@scure/bip32": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "peer": true,
+      "requires": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      }
     },
     "@scure/bip39": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
-      "integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "peer": true,
       "requires": {
-        "@noble/hashes": "~1.1.1",
-        "@scure/base": "~1.1.0"
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
       }
     },
     "@sinclair/typebox": {
@@ -6893,9 +6902,9 @@
       }
     },
     "@types/http-cache-semantics": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -6945,9 +6954,9 @@
       "integrity": "sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g=="
     },
     "@types/responselike": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "requires": {
         "@types/node": "*"
       }
@@ -7014,18 +7023,32 @@
       }
     },
     "aptos": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.20.0.tgz",
-      "integrity": "sha512-driZt7qEr4ndKqqVHMyuFsQAHy4gJ4HPQttgVIpeDfnOIEnIV7A2jyJ9EYO2A+MayuyxXB+7yCNXT4HyBFJdpA==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.21.0.tgz",
+      "integrity": "sha512-PRKjoFgL8tVEc9+oS7eJUv8GNxx8n3+0byH2+m7CP3raYOD6yFKOecuwjVMIJmgfpjp6xH0P0HDMGZAXmSyU0Q==",
       "requires": {
-        "@aptos-labs/aptos-client": "^0.0.2",
-        "@noble/hashes": "1.1.3",
-        "@scure/bip39": "1.1.0",
+        "@aptos-labs/aptos-client": "^0.1.0",
+        "@noble/hashes": "1.3.3",
+        "@scure/bip39": "1.2.1",
         "eventemitter3": "^5.0.1",
         "form-data": "4.0.0",
         "tweetnacl": "1.0.3"
       },
       "dependencies": {
+        "@noble/hashes": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+          "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="
+        },
+        "@scure/bip39": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+          "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+          "requires": {
+            "@noble/hashes": "~1.3.0",
+            "@scure/base": "~1.1.0"
+          }
+        },
         "eventemitter3": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -7054,9 +7077,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -8486,9 +8509,9 @@
       "dev": true
     },
     "keyv": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
-      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "requires": {
         "json-buffer": "3.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@identity-connect/api": "^0.4.1",
     "@identity-connect/dapp-sdk": "^0.4.3",
-    "@identity-connect/wallet-api": "^0.0.4"
+    "@identity-connect/wallet-api": "^0.0.4",
+    "@aptos-labs/wallet-adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@swc/core": "^1.3.100",
@@ -30,7 +31,6 @@
     "typescript": "^5.3.2"
   },
   "peerDependencies": {
-    "@aptos-labs/wallet-adapter-core": "^2.6.0",
     "aptos": "^1.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@identity-connect/api": "^0.4.1",
     "@identity-connect/dapp-sdk": "^0.4.3",
     "@identity-connect/wallet-api": "^0.0.4",
-    "@aptos-labs/wallet-adapter-core": "^2.6.0"
+    "@aptos-labs/wallet-adapter-core": "^3.5.0"
   },
   "devDependencies": {
     "@swc/core": "^1.3.100",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity-connect/wallet-adapter-plugin",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Identity Connect plugin to use with Aptos Wallet Adapter",
   "author": "Identity Connect Aptos",
   "main": "./dist/index.js",


### PR DESCRIPTION
Using it as a peerDependency results in forcing dapps to install wallet-adapter-core as a dependency when they install IC plugin